### PR TITLE
Update accepted venue for SimCTG

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Current NLP models heavily rely on effective representation learning algorithms.
 
 1. **Controllable Natural Language Generation with Contrastive Prefixes** *Jing Qian, Li Dong, Yelong Shen, Furu Wei, Weizhu Chen* `Findings of ACL 2022` [[pdf]](https://arxiv.org/abs/2202.13257) [[code]](https://github.com/yxuansu/SimCTG)
 
-1. **A Contrastive Framework for Neural Text Generation** *Yixuan Su, Tian Lan, Yan Wang, Dani Yogatama, Lingpeng Kong, Nigel Collier* `arXiv` [[pdf]](https://arxiv.org/abs/2202.06417) [[code]](https://github.com/yxuansu/SimCTG)
+1. **A Contrastive Framework for Neural Text Generation** *Yixuan Su, Tian Lan, Yan Wang, Dani Yogatama, Lingpeng Kong, Nigel Collier* `NeurIPS 2022` [[pdf]](https://arxiv.org/abs/2202.06417) [[code]](https://github.com/yxuansu/SimCTG)
 
 1. **Counter-Contrastive Learning for Language GANs** *Yekun Chai, Haidong Zhang, Qiyue Yin, Junge Zhang* `Findings of EMNLP 2021` [[pdf]](https://aclanthology.org/2021.findings-emnlp.415.pdf)
 


### PR DESCRIPTION
Hi @ryanzhumich,

Our work "A Contrastive Framework for Neural Text Generation" (SimCTG) has been accepted to NeurIPS 2022. Please kindly update the accepted venue. Many thanks!

Best,

Yixuan